### PR TITLE
Fix BufferEditRange Hook from incorrectly relexing the file

### DIFF
--- a/custom/4coder_terickson_language.cpp
+++ b/custom/4coder_terickson_language.cpp
@@ -982,7 +982,7 @@ BUFFER_EDIT_RANGE_SIG(language_buffer_edit_range){
     }
     
     if (do_full_relex){
-        *lex_task_ptr = async_task_no_dep(&global_async_system, do_full_lex_async,
+        *lex_task_ptr = async_task_no_dep(&global_async_system, language_do_full_lex_async,
                                           make_data_struct(&buffer_id));
     }
     


### PR DESCRIPTION
In the BufferEditRange Hook, if the partial relex fails, it falls back on a full Asyncronous lex of the buffer, However, this calls the incorrect aysnc lexer, so this is always using the C/Cpp lexer